### PR TITLE
fix: user command tier display

### DIFF
--- a/services/MemberContext.js
+++ b/services/MemberContext.js
@@ -246,7 +246,7 @@ class MemberContext {
                 if (signup.fields["Voyage"] === "V??") {
                     this.nextVoyageSignupText = `Pending <a:LoadingEmoji:1274376308327190549> `
                 } else {
-                    const tierName = signup.fields['Tier']
+                    const tierName = signup.fields['Team Name']
                     this.nextVoyageSignupText = tierName !== undefined && tierName !== ""
                         ? `Yes (${tierName.slice(0,6)}) <a:check:1209501960139702363>`
                         : `Tier not yet assigned`


### PR DESCRIPTION
It was looking at old column which is now unused
The field should show pending if voyage is v??
if user is signed up for next voyage, it should show the tier they are signed up for, if there's no tier yet (usually in the case of PO and SM), it should show "Tier not assigned"